### PR TITLE
Improve proto messages sanitizing

### DIFF
--- a/proto/nebius/applications/v1alpha1/k8s_release.sensitive.pb.go
+++ b/proto/nebius/applications/v1alpha1/k8s_release.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *K8SRelease) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [K8SRelease].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -58,13 +58,13 @@ func (x *K8SReleaseSpec) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Values = "***"
-	x.Set = map[string]string{"***": "***"}
+	x.Values = "**HIDDEN**"
+	x.Set = map[string]string{"**HIDDEN**": "**HIDDEN**"}
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [K8SReleaseSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/applications/v1alpha1/k8s_release_service.sensitive.pb.go
+++ b/proto/nebius/applications/v1alpha1/k8s_release_service.sensitive.pb.go
@@ -25,7 +25,7 @@ func (x *CreateK8SReleaseRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateK8SReleaseRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -74,7 +74,7 @@ func (x *ListK8SReleasesResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListK8SReleasesResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/common/v1/operation.sensitive.pb.go
+++ b/proto/nebius/common/v1/operation.sensitive.pb.go
@@ -47,7 +47,7 @@ func (x *Operation) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Operation].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // It also sanitizes the content of google.protobuf.Any, i.e. performs unmarshal, sanitize, marshal cycle.
 // Important: [proto.UnmarshalOptions.DiscardUnknown] = true is used.

--- a/proto/nebius/common/v1/operation_service.sensitive.pb.go
+++ b/proto/nebius/common/v1/operation_service.sensitive.pb.go
@@ -31,7 +31,7 @@ func (x *ListOperationsResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListOperationsResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // It also sanitizes the content of google.protobuf.Any, i.e. performs unmarshal, sanitize, marshal cycle.
 // Important: [proto.UnmarshalOptions.DiscardUnknown] = true is used.

--- a/proto/nebius/common/v1alpha1/operation.sensitive.pb.go
+++ b/proto/nebius/common/v1alpha1/operation.sensitive.pb.go
@@ -48,7 +48,7 @@ func (x *Operation) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Operation].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // It also sanitizes the content of google.protobuf.Any, i.e. performs unmarshal, sanitize, marshal cycle.
 // Important: [proto.UnmarshalOptions.DiscardUnknown] = true is used.

--- a/proto/nebius/common/v1alpha1/operation_service.sensitive.pb.go
+++ b/proto/nebius/common/v1alpha1/operation_service.sensitive.pb.go
@@ -31,7 +31,7 @@ func (x *ListOperationsResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListOperationsResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // It also sanitizes the content of google.protobuf.Any, i.e. performs unmarshal, sanitize, marshal cycle.
 // Important: [proto.UnmarshalOptions.DiscardUnknown] = true is used.

--- a/proto/nebius/compute/v1/instance.sensitive.pb.go
+++ b/proto/nebius/compute/v1/instance.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *Instance) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Instance].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -58,12 +58,12 @@ func (x *InstanceSpec) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.CloudInitUserData = "***"
+	x.CloudInitUserData = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [InstanceSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/compute/v1/instance_service.sensitive.pb.go
+++ b/proto/nebius/compute/v1/instance_service.sensitive.pb.go
@@ -25,7 +25,7 @@ func (x *CreateInstanceRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateInstanceRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -69,7 +69,7 @@ func (x *UpdateInstanceRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateInstanceRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -118,7 +118,7 @@ func (x *ListInstancesResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListInstancesResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/compute/v1alpha1/instance.sensitive.pb.go
+++ b/proto/nebius/compute/v1alpha1/instance.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *Instance) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Instance].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -58,12 +58,12 @@ func (x *InstanceSpec) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.CloudInitUserData = "***"
+	x.CloudInitUserData = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [InstanceSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/compute/v1alpha1/instance_service.sensitive.pb.go
+++ b/proto/nebius/compute/v1alpha1/instance_service.sensitive.pb.go
@@ -25,7 +25,7 @@ func (x *CreateInstanceRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateInstanceRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -69,7 +69,7 @@ func (x *UpdateInstanceRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateInstanceRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -118,7 +118,7 @@ func (x *ListInstancesResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListInstancesResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/access_key.sensitive.pb.go
+++ b/proto/nebius/iam/v1/access_key.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *AccessKey) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [AccessKey].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -61,12 +61,12 @@ func (x *AccessKeyStatus) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Secret = "***"
+	x.Secret = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [AccessKeyStatus].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/access_key_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/access_key_service.sensitive.pb.go
@@ -47,12 +47,12 @@ func (x *GetAccessKeySecretOnceResponse) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Secret = "***"
+	x.Secret = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [GetAccessKeySecretOnceResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -98,7 +98,7 @@ func (x *ListAccessKeysResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListAccessKeysResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/group_membership.sensitive.pb.go
+++ b/proto/nebius/iam/v1/group_membership.sensitive.pb.go
@@ -30,7 +30,7 @@ func (x *GroupMembershipWithAttributes) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [GroupMembershipWithAttributes].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/group_membership_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/group_membership_service.sensitive.pb.go
@@ -39,7 +39,7 @@ func (x *ListGroupMembershipsWithAttributesResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListGroupMembershipsWithAttributesResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/invitation.sensitive.pb.go
+++ b/proto/nebius/iam/v1/invitation.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *Invitation) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Invitation].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -59,13 +59,13 @@ func (x *InvitationSpec) Sanitize() {
 		return
 	}
 	if o, ok := x.Contact.(*InvitationSpec_Email); ok && o != nil {
-		o.Email = "***"
+		o.Email = "**HIDDEN**"
 	}
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [InvitationSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/invitation_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/invitation_service.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *CreateInvitationRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateInvitationRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -61,12 +61,12 @@ func (x *ListInvitationsRequest) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Filter = "***"
+	x.Filter = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListInvitationsRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -112,7 +112,7 @@ func (x *ListInvitationsResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListInvitationsResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -159,7 +159,7 @@ func (x *UpdateInvitationRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateInvitationRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/profile_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/profile_service.sensitive.pb.go
@@ -24,7 +24,7 @@ func (x *GetProfileResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [GetProfileResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -71,7 +71,7 @@ func (x *UserProfile) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UserProfile].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/tenant_user_account.sensitive.pb.go
+++ b/proto/nebius/iam/v1/tenant_user_account.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *TenantUserAccount) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [TenantUserAccount].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -66,7 +66,7 @@ func (x *TenantUserAccountWithAttributes) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [TenantUserAccountWithAttributes].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -105,21 +105,21 @@ func (x *UserAttributes) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Sub = proto.String("***")
-	x.Name = proto.String("***")
-	x.GivenName = proto.String("***")
-	x.FamilyName = proto.String("***")
-	x.PreferredUsername = proto.String("***")
-	x.Picture = proto.String("***")
-	x.Email = proto.String("***")
-	x.Zoneinfo = proto.String("***")
-	x.Locale = proto.String("***")
-	x.PhoneNumber = proto.String("***")
+	x.Sub = proto.String("**HIDDEN**")
+	x.Name = proto.String("**HIDDEN**")
+	x.GivenName = proto.String("**HIDDEN**")
+	x.FamilyName = proto.String("**HIDDEN**")
+	x.PreferredUsername = proto.String("**HIDDEN**")
+	x.Picture = proto.String("**HIDDEN**")
+	x.Email = proto.String("**HIDDEN**")
+	x.Zoneinfo = proto.String("**HIDDEN**")
+	x.Locale = proto.String("**HIDDEN**")
+	x.PhoneNumber = proto.String("**HIDDEN**")
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UserAttributes].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -166,7 +166,7 @@ func (x *TenantUserAccountSpec) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [TenantUserAccountSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -205,12 +205,12 @@ func (x *TenantUserAccountSpec_VisibleAttributes) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Attribute = []string{"***"}
+	x.Attribute = []string{"**HIDDEN**"}
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [TenantUserAccountSpec_VisibleAttributes].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/tenant_user_account_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/tenant_user_account_service.sensitive.pb.go
@@ -17,12 +17,12 @@ func (x *ListTenantUserAccountsRequest) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Filter = "***"
+	x.Filter = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListTenantUserAccountsRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -68,7 +68,7 @@ func (x *ListTenantUserAccountsResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListTenantUserAccountsResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/tenant_user_account_with_attributes_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/tenant_user_account_with_attributes_service.sensitive.pb.go
@@ -17,12 +17,12 @@ func (x *ListTenantUserAccountsWithAttributesRequest) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Filter = "***"
+	x.Filter = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListTenantUserAccountsWithAttributesRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -68,7 +68,7 @@ func (x *ListTenantUserAccountsWithAttributesResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListTenantUserAccountsWithAttributesResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/token_service.sensitive.pb.go
+++ b/proto/nebius/iam/v1/token_service.sensitive.pb.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	tokensanitizer "github.com/nebius/gosdk/proto/tokensanitizer"
 	proto "google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	slog "log/slog"
@@ -10,17 +11,26 @@ import (
 
 // Sanitize mutates [ExchangeTokenRequest] to remove/mask all sensitive values.
 // Sensitive fields are marked with [(nebius.sensitive) = true].
+// Fields with credentials are marked with [(nebius.credentials) = true].
 func (x *ExchangeTokenRequest) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.SubjectToken = "***"
-	x.ActorToken = "***"
+	credsSanitizer := tokensanitizer.CredentialsSanitizer()
+	sanitizeCreds := func(s string) string {
+		if !credsSanitizer.IsSupported(s) {
+			return "**HIDDEN**"
+		}
+		return credsSanitizer.Sanitize(s)
+	}
+	x.SubjectToken = sanitizeCreds(x.SubjectToken)
+	x.ActorToken = sanitizeCreds(x.ActorToken)
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ExchangeTokenRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
+// Signature is replaced by "**" in credentials.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -55,16 +65,25 @@ func (w *wrapperExchangeTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Sanitize mutates [CreateTokenResponse] to remove/mask all sensitive values.
 // Sensitive fields are marked with [(nebius.sensitive) = true].
+// Fields with credentials are marked with [(nebius.credentials) = true].
 func (x *CreateTokenResponse) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.AccessToken = "***"
+	credsSanitizer := tokensanitizer.CredentialsSanitizer()
+	sanitizeCreds := func(s string) string {
+		if !credsSanitizer.IsSupported(s) {
+			return "**HIDDEN**"
+		}
+		return credsSanitizer.Sanitize(s)
+	}
+	x.AccessToken = sanitizeCreds(x.AccessToken)
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateTokenResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
+// Signature is replaced by "**" in credentials.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/iam/v1/user_account.sensitive.pb.go
+++ b/proto/nebius/iam/v1/user_account.sensitive.pb.go
@@ -14,12 +14,12 @@ func (x *UserAccountExternalId) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.FederationUserAccountId = "***"
+	x.FederationUserAccountId = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UserAccountExternalId].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/mk8s/v1/node_group.sensitive.pb.go
+++ b/proto/nebius/mk8s/v1/node_group.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *NodeGroup) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [NodeGroup].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -63,7 +63,7 @@ func (x *NodeGroupSpec) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [NodeGroupSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -102,12 +102,12 @@ func (x *NodeTemplate) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.CloudInitUserData = "***"
+	x.CloudInitUserData = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [NodeTemplate].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/mk8s/v1/node_group_service.sensitive.pb.go
+++ b/proto/nebius/mk8s/v1/node_group_service.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *CreateNodeGroupRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateNodeGroupRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -71,7 +71,7 @@ func (x *ListNodeGroupsResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListNodeGroupsResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -115,7 +115,7 @@ func (x *UpdateNodeGroupRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateNodeGroupRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/mk8s/v1alpha1/node_group.sensitive.pb.go
+++ b/proto/nebius/mk8s/v1alpha1/node_group.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *NodeGroup) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [NodeGroup].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -63,7 +63,7 @@ func (x *NodeGroupSpec) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [NodeGroupSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -102,12 +102,12 @@ func (x *NodeTemplate) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.CloudInitUserData = "***"
+	x.CloudInitUserData = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [NodeTemplate].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/mk8s/v1alpha1/node_group_service.sensitive.pb.go
+++ b/proto/nebius/mk8s/v1alpha1/node_group_service.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *CreateNodeGroupRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateNodeGroupRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -74,7 +74,7 @@ func (x *ListNodeGroupsResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListNodeGroupsResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -118,7 +118,7 @@ func (x *UpdateNodeGroupRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateNodeGroupRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/msp/mlflow/v1alpha1/cluster.sensitive.pb.go
+++ b/proto/nebius/msp/mlflow/v1alpha1/cluster.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *Cluster) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Cluster].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -58,12 +58,12 @@ func (x *ClusterSpec) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.AdminPassword = "***"
+	x.AdminPassword = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ClusterSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/msp/mlflow/v1alpha1/cluster_service.sensitive.pb.go
+++ b/proto/nebius/msp/mlflow/v1alpha1/cluster_service.sensitive.pb.go
@@ -30,7 +30,7 @@ func (x *ListClustersResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListClustersResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -74,7 +74,7 @@ func (x *CreateClusterRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateClusterRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/msp/postgresql/v1alpha1/cluster.sensitive.pb.go
+++ b/proto/nebius/msp/postgresql/v1alpha1/cluster.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *Cluster) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Cluster].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -66,7 +66,7 @@ func (x *ClusterSpec) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ClusterSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -117,12 +117,12 @@ func (x *BootstrapSpec) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.UserPassword = "***"
+	x.UserPassword = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [BootstrapSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/msp/postgresql/v1alpha1/cluster_service.sensitive.pb.go
+++ b/proto/nebius/msp/postgresql/v1alpha1/cluster_service.sensitive.pb.go
@@ -27,7 +27,7 @@ func (x *ListClustersResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListClustersResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -71,7 +71,7 @@ func (x *CreateClusterRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateClusterRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -118,7 +118,7 @@ func (x *UpdateClusterRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateClusterRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/msp/spark/v1alpha1/cluster.sensitive.pb.go
+++ b/proto/nebius/msp/spark/v1alpha1/cluster.sensitive.pb.go
@@ -19,7 +19,7 @@ func (x *Cluster) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Cluster].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -63,7 +63,7 @@ func (x *ClusterSpec) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ClusterSpec].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -108,12 +108,12 @@ func (x *Password) Sanitize() {
 	if x == nil {
 		return
 	}
-	x.Password = "***"
+	x.Password = "**HIDDEN**"
 }
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [Password].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/nebius/msp/spark/v1alpha1/cluster_service.sensitive.pb.go
+++ b/proto/nebius/msp/spark/v1alpha1/cluster_service.sensitive.pb.go
@@ -30,7 +30,7 @@ func (x *ListClustersResponse) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [ListClustersResponse].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -74,7 +74,7 @@ func (x *CreateClusterRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [CreateClusterRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //
@@ -118,7 +118,7 @@ func (x *UpdateClusterRequest) Sanitize() {
 
 // LogValue implements [slog.LogValuer] interface. It returns sanitized copy of [UpdateClusterRequest].
 // Properly implemented [slog.Handler] must call LogValue, so sensitive values are not logged.
-// Sensitive strings and bytes are masked with `***`, other sensitive fields are omitted.
+// Sensitive strings and bytes are masked with "**HIDDEN**", other sensitive fields are omitted.
 //
 // Returning value has kind [slog.KindAny]. To extract [proto.Message], use the following code:
 //

--- a/proto/tokensanitizer/token_sanitizer.go
+++ b/proto/tokensanitizer/token_sanitizer.go
@@ -1,0 +1,117 @@
+package tokensanitizer
+
+import (
+	"strings"
+)
+
+// MaskString is the string to show instead of real token part.
+const MaskString = "**"
+
+// MaxVisiblePayloadLength is the maximum number of characters to show for unrecognized or not signed token.
+const MaxVisiblePayloadLength = 15
+
+// NoSignature is used to indicate that a token version has no signature.
+const NoSignature = -1
+
+// TokenVersion represents the structure of a token version.
+type TokenVersion struct {
+	Prefix            string
+	Delimiter         string
+	SignaturePosition int // -1 if no signature
+	TokenPartsCount   int
+}
+
+// AccessTokenVersions contains the predefined access token versions.
+//
+//nolint:gochecknoglobals,mnd // const config
+var AccessTokenVersions = map[string]TokenVersion{
+	"V0":  {Prefix: "v0.", Delimiter: ".", SignaturePosition: NoSignature, TokenPartsCount: 1},
+	"NE1": {Prefix: "ne1", Delimiter: ".", SignaturePosition: 1, TokenPartsCount: 2},
+}
+
+// CredentialsVersions contains all possible token types, which is used in app.
+//
+//nolint:gochecknoglobals,mnd // const config
+var CredentialsVersions = map[string]TokenVersion{
+	// Copy entries from AccessTokenVersions
+	"V0":  AccessTokenVersions["V0"],
+	"NE1": AccessTokenVersions["NE1"],
+
+	// Other cred types delegation and jwt
+	"DE1": {Prefix: "nd1", Delimiter: ".", SignaturePosition: 1, TokenPartsCount: 2},
+	"JWT": {Prefix: "eyJ", Delimiter: ".", SignaturePosition: 2, TokenPartsCount: 3},
+}
+
+type TokenSanitizer struct {
+	extractor TokenVersionExtractor
+}
+
+func AccessTokenSanitizer() *TokenSanitizer {
+	return &TokenSanitizer{
+		extractor: NewDefaultTokenVersionExtractor(AccessTokenVersions),
+	}
+}
+
+func CredentialsSanitizer() *TokenSanitizer {
+	return &TokenSanitizer{
+		extractor: NewDefaultTokenVersionExtractor(CredentialsVersions),
+	}
+}
+
+func NewTokenSanitizerWithCustomExtractor(versionExtractor TokenVersionExtractor) *TokenSanitizer {
+	return &TokenSanitizer{
+		extractor: versionExtractor,
+	}
+}
+
+// Sanitize sanitizes the input token based on its version, returns sanitized token.
+func (ts *TokenSanitizer) Sanitize(token string) string {
+	if token == "" {
+		return ""
+	}
+
+	version, recognized := ts.extractor.Extract(token)
+	if !recognized {
+		return sanitizeUnrecognized(token)
+	}
+
+	tokenParts := strings.Split(token, version.Delimiter)
+
+	if version.SignaturePosition == NoSignature {
+		return sanitizeNoSignature(token, version.Prefix)
+	}
+
+	if len(tokenParts) <= version.SignaturePosition {
+		return sanitizeUnrecognized(token)
+	}
+
+	tokenParts[version.SignaturePosition] = MaskString
+	return strings.Join(tokenParts, version.Delimiter)
+}
+
+// IsSupported check version is supported and token parts count is suitable for this token type.
+func (ts *TokenSanitizer) IsSupported(token string) bool {
+	version, recognized := ts.extractor.Extract(token)
+	if !recognized {
+		return false
+	}
+	tokenParts := strings.Split(token, version.Delimiter)
+	return len(tokenParts) >= version.TokenPartsCount
+}
+
+// sanitizeNoSignature handles sanitization for tokens without a signature.
+func sanitizeNoSignature(token, prefix string) string {
+	payload := strings.TrimPrefix(token, prefix)
+	if len(payload) <= MaxVisiblePayloadLength {
+		return token
+	}
+	return token[:MaxVisiblePayloadLength+len(prefix)] + MaskString
+}
+
+// sanitizeUnrecognized handles sanitization for unrecognized token structures.
+func sanitizeUnrecognized(token string) string {
+	if len(token) <= MaxVisiblePayloadLength {
+		return token + MaskString
+	}
+	return token[:MaxVisiblePayloadLength] + MaskString
+}

--- a/proto/tokensanitizer/token_sanitizer_test.go
+++ b/proto/tokensanitizer/token_sanitizer_test.go
@@ -1,0 +1,88 @@
+package tokensanitizer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nebius/gosdk/proto/tokensanitizer"
+)
+
+func TestAccessTokenSanitizer(t *testing.T) {
+	t.Parallel()
+	sanitizer := tokensanitizer.AccessTokenSanitizer()
+
+	testCases := []struct {
+		name      string
+		input     string
+		expected  string
+		supported bool
+	}{
+		{"Empty input", "", "", false},
+		{"V0 short token", "v0.short", "v0.short", true},
+		{"V0 long token", "v0.somelongpayloadhere", "v0.somelongpayload**", true},
+		{"NE1 valid token", "ne1somepayload.signaturehere", "ne1somepayload.**", true},
+		{"NE1 invalid token", "ne1invalidtokens", "ne1invalidtoken**", false},
+		{"Unrecognized short", "unknown", "unknown**", false},
+		{"Unrecognized long", "unrecognizedtoken", "unrecognizedtok**", false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			result := sanitizer.Sanitize(testCase.input)
+			assert.Equal(t, testCase.supported, sanitizer.IsSupported(testCase.input))
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}
+
+func TestCredentialsTokenSanitizer(t *testing.T) {
+	t.Parallel()
+	sanitizer := tokensanitizer.CredentialsSanitizer()
+
+	testCases := []struct {
+		name      string
+		input     string
+		expected  string
+		supported bool
+	}{
+		{"Empty input", "", "", false},
+		{"V0 long token", "v0.somelongpayloadhere", "v0.somelongpayload**", true},
+		{"NE1 valid token", "ne1somepayload.signaturehere", "ne1somepayload.**", true},
+		{"NE1 invalid token", "ne1invalidtokens", "ne1invalidtoken**", false},
+		{"Unrecognized short", "unknown", "unknown**", false},
+		{"JWT valid token", "eyJfast.payload.signature", "eyJfast.payload.**", true},
+		{"JWT with extra info", "eyJfast.payload.signature.aftersignature", "eyJfast.payload.**.aftersignature", true},
+		{"JWT invalid token", "eyJfast.payload", "eyJfast.payload**", false},
+		{"Delegation valid token", "nd1payload.signature", "nd1payload.**", true},
+		{"Delegation invalid token", "nd1payload", "nd1payload**", false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			result := sanitizer.Sanitize(testCase.input)
+			assert.Equal(t, testCase.supported, sanitizer.IsSupported(testCase.input))
+			assert.Equal(t, testCase.expected, result)
+		})
+	}
+}
+
+func TestCustomTokenVersion(t *testing.T) {
+	t.Parallel()
+	versions := map[string]tokensanitizer.TokenVersion{
+		"V0":  {Prefix: "v0.", Delimiter: ".", SignaturePosition: tokensanitizer.NoSignature, TokenPartsCount: 1},
+		"NE1": {Prefix: "ne1", Delimiter: ".", SignaturePosition: 1, TokenPartsCount: 2},
+		"V2":  {Prefix: "v2:", Delimiter: "-", SignaturePosition: 2, TokenPartsCount: 3},
+	}
+	sanitizer := tokensanitizer.NewTokenSanitizerWithCustomExtractor(
+		tokensanitizer.NewDefaultTokenVersionExtractor(versions),
+	)
+
+	input := "v2:payload-moredata-signature"
+	expected := "v2:payload-moredata-**"
+	result := sanitizer.Sanitize(input)
+	assert.True(t, sanitizer.IsSupported(input))
+	assert.Equal(t, expected, result)
+}

--- a/proto/tokensanitizer/token_version_extractor.go
+++ b/proto/tokensanitizer/token_version_extractor.go
@@ -1,0 +1,29 @@
+package tokensanitizer
+
+import (
+	"strings"
+)
+
+// TokenVersionExtractor is an interface for extracting token versions.
+type TokenVersionExtractor interface {
+	// Extract TokenVersion and a boolean indicating if the version was recognized for given token.
+	Extract(token string) (TokenVersion, bool)
+}
+
+type DefaultTokenVersionExtractor struct {
+	versions map[string]TokenVersion
+}
+
+func NewDefaultTokenVersionExtractor(versions map[string]TokenVersion) *DefaultTokenVersionExtractor {
+	return &DefaultTokenVersionExtractor{versions: versions}
+}
+
+// Extract returns the TokenVersion and true if recognized, or an empty TokenVersion and false if not.
+func (e *DefaultTokenVersionExtractor) Extract(token string) (TokenVersion, bool) {
+	for _, version := range e.versions {
+		if strings.HasPrefix(token, version.Prefix) {
+			return version, true
+		}
+	}
+	return TokenVersion{}, false
+}

--- a/proto/tokensanitizer/token_version_extractor_test.go
+++ b/proto/tokensanitizer/token_version_extractor_test.go
@@ -1,0 +1,67 @@
+package tokensanitizer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nebius/gosdk/proto/tokensanitizer"
+)
+
+func TestDefaultTokenVersionExtractor(t *testing.T) {
+	t.Parallel()
+	versions := map[string]tokensanitizer.TokenVersion{
+		"V0":  {Prefix: "v0.", Delimiter: ".", SignaturePosition: tokensanitizer.NoSignature, TokenPartsCount: 1},
+		"NE1": {Prefix: "ne1", Delimiter: ".", SignaturePosition: 1, TokenPartsCount: 2},
+		"V2":  {Prefix: "v2:", Delimiter: "-", SignaturePosition: 2, TokenPartsCount: 2},
+	}
+
+	extractor := tokensanitizer.NewDefaultTokenVersionExtractor(versions)
+
+	testCases := []struct {
+		name            string
+		input           string
+		expectedVersion tokensanitizer.TokenVersion
+		expectedFound   bool
+	}{
+		{
+			name:            "V0 token",
+			input:           "v0.sometokendata",
+			expectedVersion: versions["V0"],
+			expectedFound:   true,
+		},
+		{
+			name:            "NE1 token",
+			input:           "ne1sometokendata.signature",
+			expectedVersion: versions["NE1"],
+			expectedFound:   true,
+		},
+		{
+			name:            "V2 token",
+			input:           "v2:part1-part2-signature",
+			expectedVersion: versions["V2"],
+			expectedFound:   true,
+		},
+		{
+			name:            "Unrecognized token",
+			input:           "unknowntoken",
+			expectedVersion: tokensanitizer.TokenVersion{},
+			expectedFound:   false,
+		},
+		{
+			name:            "Empty token",
+			input:           "",
+			expectedVersion: tokensanitizer.TokenVersion{},
+			expectedFound:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			version, found := extractor.Extract(testCase.input)
+			assert.Equal(t, testCase.expectedFound, found)
+			assert.Equal(t, testCase.expectedVersion, version)
+		})
+	}
+}


### PR DESCRIPTION
1. Mask only the signature part for credentials fields.
2. Use `**HIDDEN**` for sensitive fields.
